### PR TITLE
Removed OREDIC Splinter CRafting

### DIFF
--- a/src/scripts/Vanilla/CraftingShapeless.zs
+++ b/src/scripts/Vanilla/CraftingShapeless.zs
@@ -4,7 +4,6 @@ import minetweaker.item.IItemStack;
 
 recipes.addShapeless(obbyTotem, [obbyTile, obbyTile, obbyTile, obbyTile]);
 recipes.addShapeless(bonemeal * 3, [bone1]);
-recipes.addShapeless(woodsplinter * 4, [woodlog]);
 recipes.addShapeless(redstone, [lavabuck, sandOredict]);
 recipes.addShapeless(wool, [sheepEssence, sheepEssence, oreTierMinicoEssence, oreTierMinicoEssence, oreTierMinicoEssence,oreTierMinicoEssence, oreTierMinicoEssence, oreTierMinicoEssence, oreTierMinicoEssence]);
 


### PR DESCRIPTION
Causes all splinters to be DEfaulted to OAk
